### PR TITLE
Feature: Add more index pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -96,7 +96,7 @@ const config: Config = {
                     label: 'Wiki',
                     className: 'header-wiki-link',
                     position: 'left',
-                    to: 'wiki/geyser/',
+                    to: 'wiki/',
                     items: [
                         {
                             type: 'doc',
@@ -105,17 +105,17 @@ const config: Config = {
                         },
                         {
                             type: 'doc',
-                            docId: 'floodgate/setup',
+                            docId: 'floodgate/index',
                             label: 'Floodgate',
                         },
                         {
                             type: 'doc',
-                            docId: 'api/api.geysermc.org/global-api',
+                            docId: 'api/index',
                             label: 'REST APIs',
                         },
                         {
                             type: 'doc',
-                            docId: 'other/geyseroptionalpack',
+                            docId: 'other/index',
                             label: 'Other',
                         },
                     ]

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -84,7 +84,7 @@
     "message": "You must have a plan with a dedicated IP. In Geyser's config, uncomment the `bedrock address` and set it to the public IP of your server (e.g. `address: 51.79.129.18`). Leave the port as `19132`. Under the home tab, select 'Enable UDP Network' and restart the server. See Bisect's [article](https://www.bisecthosting.com/clients/index.php?rp=/knowledgebase/193/How-to-install-Geyser-and-Floodgate-on-a-Minecraft-Java-server.html) for full instructions. If you still cannot connect after following these instructions, contact Bisect Support as they reportedly have UDP disabled on some nodes."
   },
   "providers.provider.bloomhost.description": {
-    "message": "https://docs.bloom.host/plugins/geysermc/"
+    "message": "See [Bloom's documentation](https://docs.bloom.host/plugins/geysermc/) for setup instructions."
   },
   "providers.provider.craft-hosting.description": {
     "message": "Set the Bedrock port to the Java server's port and connect with that port; note that this provider appears to only provide service in Russia."

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -13,6 +13,7 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
     // By default, Docusaurus generates a sidebar from the docs folder structure
     apiSidebar: [
+        "api/index",
         {
             type: "category",
             label: "api.geysermc.org",
@@ -130,14 +131,16 @@ const sidebars: SidebarsConfig = {
     ],
 
     otherSidebar: [
-        'other/geyseroptionalpack',
-        'other/hurricane',
+        'other/index',
         'other/geyserconnect',
+        'other/thirdpartycosmetics',
+        'other/geyseroptionalpack',
         'other/community-geyser-projects',
+        'other/hurricane',
+        'other/hydraulic',
         'other/test-server',
         'other/developer-guide',
-        'other/discord-bot-usage',
-        'other/hydraulic'
+        'other/discord-bot-usage'
     ]
 };
 

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -225,7 +225,7 @@ export const providersData: Providers = {
             url: 'https://www.bloom.host/',
             description: translate({
                 id: 'providers.provider.bloomhost.description',
-                message: "https://docs.bloom.host/plugins/geysermc/"
+                message: "See [Bloom's documentation](https://docs.bloom.host/plugins/geysermc/) for setup instructions."
             })
         },
         {

--- a/wiki/api/index.mdx
+++ b/wiki/api/index.mdx
@@ -1,0 +1,28 @@
+---
+title: Overview
+permalink: /api/
+description: 'These REST APIs provide web endpoints to query different information.'
+---
+
+import DocCardList from '@theme/DocCardList'
+
+# Overview of available REST APIs
+
+Currently, there are two different Rest APIs you can use.
+
+<DocCardList items={[
+    {
+        "type": "link",
+        "label": "Geyser Global API",
+        "description": "Provides information on players, such as xuids, skins, or linking information.",
+        "href": "/wiki/api/global",
+        "unlisted": false
+    },
+    {
+        "type": "link",
+        "label": "Downloads API",
+        "description": "Provides information and download links to projects on the Downloads API",
+        "href": "/wiki/api/downloads",
+        "unlisted": false
+    }
+]} />

--- a/wiki/geyser/anticheat-compatibility.md
+++ b/wiki/geyser/anticheat-compatibility.md
@@ -15,20 +15,21 @@ This is a community-compiled list and does not indicate any endorsement from Gey
 Full Compatibility (Checks Bedrock Players Accurately)
 
 - [AntiAura](https://www.spigotmc.org/resources/1368/) (Paid) - Last checked on 24th January 2023
-- [Themis](https://www.spigotmc.org/resources/90766/) - Last checked on 1st January 2024
-- [Spartan: Bedrock Edition](https://builtbybit.com/resources/12832/) (Paid) - Last checked on 4th June 2024
+- [LightAntiCheat](https://modrinth.com/plugin/lightanticheat) - Last checked on 19rd July 2024
+- [Spartan: Bedrock Edition](https://builtbybit.com/resources/12832/) (Paid) - Last checked on 18th July 2024
+- [Themis](https://www.spigotmc.org/resources/90766/) - Last checked on 11th July 2024
 
 Partially Compatible (Does not Check/Ignores Bedrock Players)
 
-- [GrimAC](https://github.com/MWHunter/Grim) - Last checked on 23rd May 2024
-- [Intave](https://intave.ac) (Paid) Requires [GeyserMC addon](https://github.com/intave/bedrock) - Last checked on 24st May 2024
-- [Matrix](https://matrix.rip/) (Paid) - Last checked on 6th June 2024
-- [Spartan: Java Edition](https://www.spigotmc.org/resources/25638/) (Paid) - Last checked on 4th June 2024
-- [Vulcan](https://www.spigotmc.org/resources/83626/) (Paid) - Last checked on 3rd June 2024
-- [Verus](https://verus.ac) (Paid) - Last checked on 10th September 2023
+- [GrimAC](https://github.com/MWHunter/Grim) - Last checked on 30th June 2024
+- [Intave](https://intave.ac) (Paid) Requires [GeyserMC addon](https://github.com/intave/bedrock) - Last checked on 2nd July 2024
+- [Matrix](https://matrix.rip/) (Paid) - Last checked on 23rd July 2024
+- [Spartan: Java Edition](https://www.spigotmc.org/resources/25638/) (Paid) - Last checked on 18th July 2024
+- [Verus](https://verus.ac) (Paid) - Last checked on 4th February 2024
+- [Vulcan](https://www.spigotmc.org/resources/83626/) (Paid) - Last checked on 20th July 2024
 
 Incompatible (False Positives on Bedrock Players, no Compatibility at All)
 
-- [NoCheatPlus](https://ci.codemc.io/job/Updated-NoCheatPlus/job/Updated-NoCheatPlus/) ([Compat NCP](https://github.com/Updated-NoCheatPlus/CompatNoCheatPlus/) is an addon that enables Partial Compatibility) - Last checked on 12th May 2024
 - [GodsEye](https://www.spigotmc.org/resources/69595/) ([GodsEyeGeyserMC](https://github.com/TheDejavu/GodsEyeGeyserMC/releases) is an addon that enables Partial Compatibility) (Paid) - Last checked on 23rd March 2024
+- [NoCheatPlus](https://ci.codemc.io/job/Updated-NoCheatPlus/job/Updated-NoCheatPlus/) ([Compat NCP](https://github.com/Updated-NoCheatPlus/CompatNoCheatPlus/) is an addon that enables Partial Compatibility) - Last checked on 14th July 2024
 - [Wraith](https://www.spigotmc.org/resources/66887/) (Paid) - Last checked on 26th January 2023

--- a/wiki/geyser/api.md
+++ b/wiki/geyser/api.md
@@ -21,9 +21,9 @@ The Geyser API offers events to subscribe to, or information on whether a player
 It can be used easily in Geyser Extensions, see [here](/wiki/geyser/extensions) for details on those.
 
 **Quick overview:**   
-<div class="alert alert-info" role="alert">
+:::info
     Note: To see full, detailed documentation, see the <a href="https://repo.opencollab.dev/javadoc/maven-snapshots/org/geysermc/geyser/api/latest">javadocs</a>.
-</div>
+:::
 
 #### [GeyserApi](https://github.com/GeyserMC/Geyser/blob/master/api/src/main/java/org/geysermc/geyser/api/GeyserApi.java): {#geyserapi}
 The GeyserApi interface serves as a central access point to various functionalities provided by the Geyser API, providing methods to e.g. interact with player connections.
@@ -49,10 +49,10 @@ Used to check if the given UUID of an **online** player is a Bedrock player.
 Used to get the [Connection](https://github.com/GeyserMC/api/blob/master/base/src/main/java/org/geysermc/api/connection/Connection.java) of an **online** player.  
 This method will return null if the player is not a Bedrock player.
 
-<div class="alert alert-info" role="alert">
+:::info
     You don't need to wait until the Bedrock player is online to use the getPlayer and isBedrockPlayer methods.  
     You can even use them in the pre-login events.
-</div>
+:::
 
 `GeyserApi#sendForm(UUID, Form(Builder))`  
 Used to send a form to the Bedrock player with the given UUID.  

--- a/wiki/geyser/common-issues.md
+++ b/wiki/geyser/common-issues.md
@@ -26,7 +26,7 @@ To fix "Unable to connect to world" with no console errors, see [here](/wiki/gey
 *If the Geyser instance is locally hosted:* try using `localhost` or `0.0.0.0` as the IP address.
 *If that doesn't work, or your Geyser instance is on another computer in the network*: use your **local** IPv4 address.
 
-:::danger
+:::warning
 
 See [here](/wiki/geyser/fixing-unable-to-connect-to-world/) for fixing "Unable to Connect to World" with no console errors
 

--- a/wiki/geyser/events.md
+++ b/wiki/geyser/events.md
@@ -56,9 +56,9 @@ public class ExampleMod implements ModInitializer, EventRegistrar {
     }
 }
 ```
-<div class="alert alert-info" role="alert">
-    Do note: We cannot directly register the event bus in the mod initializer, since the Geyser API would not be loaded yet.
-</div>
+:::info
+    Note: We cannot directly register the event bus in the mod initializer, since the Geyser API would not be loaded yet.
+:::
 
 Therefore, we register it in the server starting event provided by the Fabric API.
 

--- a/wiki/geyser/fixing-unable-to-connect-to-world.md
+++ b/wiki/geyser/fixing-unable-to-connect-to-world.md
@@ -7,17 +7,17 @@ description: Common issues and solutions for the 'Unable to Connect to World' er
 This is by far the most common error people get when attempting to set up Geyser. Here's some steps on how to solve it.
 Usually, this error is caused by improper configuration of Geyser, or issues with your network.
 
-<div class="alert alert-warning" role="alert">
+:::warning
 	If you are using a Minecraft server hosting provider (e.g. Aternos, or Apex Hosting), you should refer to the hosting provider setup instructions on 
 the <a href="/wiki/geyser/setup/">setup</a> page. Following these will most likely resolve the issue!
-</div>
+:::
 
 If you are not using a Minecraft server hosting provider, carry on.
 
-<div class="alert alert-info" role="alert">
+:::info
 	To check if your server is (theoretically) reachable on Bedrock edition, try running the following command in your server console:
     <code>geyser connectiontest &lt;ip&gt;:&lt;port&gt;</code>, and see what it suggests to try.
-</div>
+:::
 
 ### Java Edition players can't connect! {#java-edition-players-cant-connect}
 

--- a/wiki/geyser/setup/provider/modded-servers.mdx
+++ b/wiki/geyser/setup/provider/modded-servers.mdx
@@ -6,7 +6,7 @@ description: Learn how to set up Geyser on your Fabric or NeoForge server from a
 import { Versions } from '@site/src/components/Versions'
 
 :::caution
-Geyser-Fabric and Geyser-NeoForge run **only** on a <Versions platform="java"/>.  
+Geyser-Fabric and Geyser-NeoForge run **only** on a <Versions platform="java"/> server.
 See [this page](/wiki/geyser/supported-versions#using-geyser-fabric-or-geyser-neoforge-on-servers-that-do-not-run-) for more details.
 :::
 

--- a/wiki/geyser/setup/self/modded-servers.mdx
+++ b/wiki/geyser/setup/self/modded-servers.mdx
@@ -7,7 +7,7 @@ hide_title: true
 import { Versions } from '@site/src/components/Versions'
 
 :::caution
-Geyser-Fabric and Geyser-NeoForge run  **only** on a <Versions platform="java"/>.
+Geyser-Fabric and Geyser-NeoForge run  **only** on a <Versions platform="java"/> server.
 See [this page](/wiki/geyser/supported-versions#using-geyser-fabric-or-geyser-neoforge-on-servers-that-do-not-run-) for more details.
 :::
 

--- a/wiki/geyser/supported-hosting-providers.mdx
+++ b/wiki/geyser/supported-hosting-providers.mdx
@@ -5,7 +5,7 @@ description: A list of hosting providers and their support for Geyser.
 
 import { Provider } from "@site/src/components/Provider";
 
-:::danger
+:::caution
 
 This list is incomplete. Please open a [PR](https://github.com/GeyserMC/GeyserWebsite/pulls) or contact us on [Discord](https://discord.gg/geysermc) if the information is incorrect, or you want to add a new hosting provider!
 
@@ -13,11 +13,11 @@ This list is incomplete. Please open a [PR](https://github.com/GeyserMC/GeyserWe
 
 :::caution
 
-It should also be noted that these providers may not be verified by the Geyser team, and the server providers below are reported as working by members of the community.
+These providers are not verified by the Geyser team, and the server providers below are reported as working by members of the community.
 
 :::
 
-:::caution
+:::info
 
 Using a <i>"Free Host"</i> may not give you the best experience <i>at all</i>. If you want better support, more freedom to control your server, and learn how to run one, PLEASE pay for a server.
 

--- a/wiki/index.mdx
+++ b/wiki/index.mdx
@@ -1,0 +1,42 @@
+---
+title: Overview of this wiki
+permalink: /wiki/
+description: 'This page provides an overview over all sections of the GeyserMC wiki'
+---
+
+import DocCardList from '@theme/DocCardList'
+
+# Overview
+
+The GeyserMC wiki offers guides on different projects. Select the one you are interested in below!
+
+<DocCardList items={[
+    {
+        "type": "link",
+        "label": "Geyser",
+        "href": "/wiki/geyser/",
+        "docId": "geyser/index",
+        "unlisted": false
+    },
+    {
+        "type": "link",
+        "label": "Floodgate",
+        "href": "/wiki/floodgate/",
+        "docId": "floodgate/index",
+        "unlisted": false
+    },
+    {
+        "type": "link",
+        "label": "Other projects",
+        "href": "/wiki/other/",
+        "docId": "other/index",
+        "unlisted": false
+    },
+    {
+        "type": "link",
+        "label": "REST APIs",
+        "href": "/wiki/api/",
+        "docId": "api/index",
+        "unlisted": false
+    }
+]} />

--- a/wiki/other/index.mdx
+++ b/wiki/other/index.mdx
@@ -1,0 +1,30 @@
+---
+title: Overview
+permalink: /other/
+description: 'Other projects or guides not directly referring to Geyser or Floodgate.'
+---
+
+import DocCardList from '@theme/DocCardList'
+import { useDocById } from '@docusaurus/theme-common/internal'
+
+# Overview of Other projects
+
+The "other" category provides you with information about different projects that are not Geyser or Floodgate.
+This includes community projects, but also other projects by the GeyserMC team, such as Hurricane or Hydraulic.
+
+<DocCardList items={[
+    'community-geyser-projects',
+    'hurricane',
+    'geyseroptionalpack',
+    'thirdpartycosmetics',
+    'hydraulic',
+    'geyserconnect',
+].map((id) => {
+    const metadata = useDocById("other/" + id)
+    return {
+        type: 'link',
+        label: metadata.title,
+        href: id,
+        docId: 'other/' + id
+    }
+})} />

--- a/wiki/other/root.md
+++ b/wiki/other/root.md
@@ -1,7 +1,0 @@
----
-title: Other
-permalink: /other/
-description: Information about other Geyser-related projects.
----
-
-# Other


### PR DESCRIPTION
This would resolve that wiki.geysermc.org is currently directing to geysermc.org/wiki, a page that currently does not exist. It also provides a clearer structure by providing users with an overview page to allow them to jump to interesting/the most important articles.